### PR TITLE
Handle System V extended filename records

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -153,6 +153,40 @@ class TestRead(_BaseTestInTempDir, unittest.TestCase):
 
         archive.close()
 
+    def test_systemv(self):
+        with open('systemv.ar', 'wb') as fp:
+            fp.write(
+                b'!<arch>\n'
+                b'//                                '
+                b'              20        `\n'
+                b'file_a.o/\nfile_b.o/\n'
+                b'/0              1464380990  501   '
+                b'20    100644  16        `\n'
+                b'this is file_a.o'
+                b'/10             1464380990  501   '
+                b'20    100644  16        `\n'
+                b'this is file_b.o'
+                b'file_c.o/       1464380990  501   '
+                b'20    100644  16        `\n'
+                b'this is file_c.o'
+            )
+
+        with unix_ar.open('systemv.ar', 'r') as archive:
+            self.assertEqual(
+                [(e.name, e.size, e.mtime, e.perms, e.uid, e.gid, e.offset)
+                 for e in archive.infolist()],
+                [(b'file_a.o/', 16, 1464380990, 0o100644, 501, 20, 88),
+                 (b'file_b.o/', 16, 1464380990, 0o100644, 501, 20, 164),
+                 (b'file_c.o/', 16, 1464380990, 0o100644, 501, 20, 240)])
+
+            archive.extractall('all')
+            with open('all/file_a.o', 'rb') as fp:
+                self.assertEqual(fp.read(), b'this is file_a.o')
+            with open('all/file_b.o', 'rb') as fp:
+                self.assertEqual(fp.read(), b'this is file_b.o')
+            with open('all/file_c.o', 'rb') as fp:
+                self.assertEqual(fp.read(), b'this is file_c.o')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unix_ar.py
+++ b/unix_ar.py
@@ -9,6 +9,16 @@ _open = open
 CHUNKSIZE = 4096
 
 
+def try_parse_int(s, base=10, val=None):
+    """
+    Try to parse an integer, return `val` on failure.
+    """
+    try:
+        return int(s, base)
+    except ValueError:
+        return val
+
+
 def utf8(s):
     """
     Keeps bytes, converts unicode into UTF-8.
@@ -73,11 +83,11 @@ class ArInfo(object):
         # 58  2   File magic                      0x60 0x0A
         name, mtime, uid, gid, perms, size, magic = (struct.unpack('16s12s6s6s8s10s2s', buffer))
         name = utf8(name).rstrip(b' ')
-        mtime = int(mtime, 10)
-        uid = int(uid, 10)
-        gid = int(gid, 10)
-        perms = int(perms, 8)
-        size = int(size, 10)
+        mtime = try_parse_int(mtime, 10)
+        uid = try_parse_int(uid, 10)
+        gid = try_parse_int(gid, 10)
+        perms = try_parse_int(perms, 8)
+        size = try_parse_int(size, 10)
         if magic != b'\x60\n':
             raise ValueError("Invalid file signature")
         return cls(name, size, mtime, perms, uid, gid)

--- a/unix_ar.py
+++ b/unix_ar.py
@@ -375,6 +375,12 @@ class ArFile(object):
             self._entries = None
             self._name_map = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
 
 def open(file, mode='r'):
     """


### PR DESCRIPTION
Adds support for reading [System V extended filename records](https://en.wikipedia.org/wiki/Ar_(Unix)#System_V_(or_GNU)_variant) as found in archives produced by e.g. the GCC archiver.