### PR TITLE
Improve wheel tags and documentation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 ignore = F821, E731

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+license_files =
+    LICENSE.txt
+
 [flake8]
 max-line-length = 120
 ignore = F821, E731


### PR DESCRIPTION
This PR avoid reporting this package as a universal wheel since it is now only Python 3.6
(which is a possible problem of its own)
It also adds the license file to the built wheel

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>